### PR TITLE
Pinning node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,4 @@
 sudo: true
-language: node_js
-  node_js:
-    - 9
 
 matrix:
   include:
@@ -9,7 +6,7 @@ matrix:
       services: docker
       language: node_js
       node_js:
-        - node
+        - 10
         - 9
       addons:
         apt:
@@ -30,7 +27,7 @@ matrix:
       osx_image: xcode9.4
       language: node_js
       node_js:
-        - node
+        - 10
         - 9
       env:
         - ELECTRON_CACHE=$HOME/.cache/electron

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 sudo: true
+language: node_js
+  node_js:
+    - 9
 
 matrix:
   include:


### PR DESCRIPTION
The 23 of Oct [Node v11](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V11.md#2018-10-23-version-1100-current-jasnell) was released.

The `node` tag in Travis means `latest` (see [here](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions)) and seems that the v11 is failing for some reason.

Removed the tag to use only Node v10 and v9.
Is it possible to use the `allow_failures` flag for `node` and test the latest release while not failing the build.