### PR TITLE
VS Code-specific changes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "yarn dev",
+            "cwd": "${workspaceRoot}",
+            "runtimeExecutable": "yarn",
+            "runtimeArgs": [
+              "dev"
+            ],
+            "stopOnEntry": false,
+            "port": 55614
+          },    
+    ]
+}

--- a/GDLauncher.code-workspace
+++ b/GDLauncher.code-workspace
@@ -18,7 +18,6 @@
 		"javascript.format.enable": true,
 		"typescript.validate.enable": false,
 		"typescript.format.enable": false,
-		"workbench.colorTheme": "Atom One Dark",
 		"breadcrumbs.enabled": true,
 		"workbench.editor.highlightModifiedTabs": true,
     "search.showLineNumbers": true,


### PR DESCRIPTION
Removes the theme from workspace settings, and adds a launch.json for easy launching