### PR TITLE
Fix curseforge href

### DIFF
--- a/app/utils/cursemeta.js
+++ b/app/utils/cursemeta.js
@@ -34,7 +34,7 @@ export const getAddonFiles = async (addonID: number | string) => {
 
 export const getAddonDescription = async (addonID: number | string) => {
   const url = `${CURSEMETA_API_URL}/addon/${addonID}/description`;
-  return makeRequest(url);
+  return makeRequest(url).then(data => data.replace(/\/linkout\?remoteUrl\=/g,'').replace(/%252f/g, '/').replace(/%253a/g, ':').replace(/%253f/g, '?').replace(/%253d/g, '\='));
 };
 
 export const getAddonFile = async (

--- a/app/utils/cursemeta.js
+++ b/app/utils/cursemeta.js
@@ -50,7 +50,7 @@ export const getAddonFileChangelog = async (
   fileID: number | string
 ) => {
   const url = `${CURSEMETA_API_URL}/addon/${addonID}/file/${fileID}/changelog`;
-  return makeRequest(url);
+  return makeRequest(url).then(data => data.replace(/\/linkout\?remoteUrl\=/g,'').replace(/%252f/g, '/').replace(/%253a/g, ':').replace(/%253f/g, '?').replace(/%253d/g, '\='));
 };
 
 export const getAddonFileIDFromVersion = async (


### PR DESCRIPTION
This does make the links usable that are mangled.
It's not ideal but gets the job done easily.

Still just learning javascript/electron/nodejs/etc so I don't know if there is an easy way to just target the anchor hrefs in the return text.