### PR TITLE
Fix Forge Manager version sorting

### DIFF
--- a/app/components/InstanceManagerModal/Settings/ForgeManager.js
+++ b/app/components/InstanceManagerModal/Settings/ForgeManager.js
@@ -16,6 +16,7 @@ import {
   GDL_LEGACYJAVAFIXER_MOD_URL
 } from '../../../constants';
 import vCompare from '../../../utils/versionsCompare';
+import vSort from 'version-sort';
 import colors from '../../../style/theme/colors.scss';
 import styles from './ForgeManager.scss';
 
@@ -127,7 +128,7 @@ class Instances extends Component<Props> {
           >
             {this.props.forgeVersions[this.props.data.version] &&
               _.reverse(
-                this.props.forgeVersions[this.props.data.version].slice()
+                vSort(this.props.forgeVersions[this.props.data.version]).slice()
               ).map(ver => (
                 <Select.Option key={ver} value={ver}>
                   {ver}


### PR DESCRIPTION
I saw this bug today when I installed and used the launcher the first time. I checked to see that it had already been reported so I decided to fix it! I hope this helps even if it is incredibly small.

Fixes #303
![image](https://user-images.githubusercontent.com/3623122/77371928-d65a6300-6d3a-11ea-8b45-ae7670623fdc.png)
