### PR TITLE
Fix for linux updater.

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -363,7 +363,7 @@ ipcMain.handle('installUpdateAndQuitOrRestart', async (e, quitAfterInstall) => {
     } else {
       // Linux
       const updateScript = spawn(
-        `sleep 2 && cp -lrfv "${path.join(
+        `sleep 2 && cp -lrf "${path.join(
           tempFolder,
           'update'
         )}"/* "." && rm -rf "${path.join(tempFolder, 'update')}"${

--- a/public/electron.js
+++ b/public/electron.js
@@ -362,16 +362,21 @@ ipcMain.handle('installUpdateAndQuitOrRestart', async (e, quitAfterInstall) => {
       });
     } else {
       // Linux
-      spawn(
-        `mv -v "${path.join(tempFolder, 'update', '*')}" "."${
+      const updateScript = spawn(
+        `sleep 2 && cp -lrfv "${path.join(
+          tempFolder,
+          'update'
+        )}"/* "." && rm -r "${path.join(tempFolder, 'update')}"${
           quitAfterInstall ? '' : ` && "${app.getPath('exe')}"`
         }`,
         {
           cwd: path.dirname(app.getPath('exe')),
           detached: true,
-          shell: true
+          shell: true,
+          stdio: 'ignore'
         }
       );
+      updateScript.unref();
     }
     app.quit();
     app.exit();

--- a/public/electron.js
+++ b/public/electron.js
@@ -366,7 +366,7 @@ ipcMain.handle('installUpdateAndQuitOrRestart', async (e, quitAfterInstall) => {
         `sleep 2 && cp -lrfv "${path.join(
           tempFolder,
           'update'
-        )}"/* "." && rm -r "${path.join(tempFolder, 'update')}"${
+        )}"/* "." && rm -rf "${path.join(tempFolder, 'update')}"${
           quitAfterInstall ? '' : ` && "${app.getPath('exe')}"`
         }`,
         {


### PR DESCRIPTION
- Named Spawn so unref can be called on child.
- Changed MV to CP since MV can't overwrite any folders.
- Added sleep 1 to give the app time to close.
- Added RM to remove the update files after copy is completed.
- stdio to ignore to not inerite parrent