### PR TITLE
Fixes bug where login info corrupts on auth refresh.

### DIFF
--- a/app/actions/auth.js
+++ b/app/actions/auth.js
@@ -51,7 +51,6 @@ export function login(username, password, remember) {
           uuid: data.selectedProfile.id,
           userID: data.user.id
         };
-        console.log(data);
         if (remember) {
           store.set({
             user: {
@@ -141,7 +140,9 @@ export function checkAccessToken() {
           );
           if (newUserData) {
             const payload = {
-              username: newUserData.selectedProfile.name,
+              email: userData.email, // email doesn't change when we're refreshing token
+              username: newUserData.user.username,
+              displayName: newUserData.selectedProfile.name,
               accessToken: newUserData.accessToken,
               uuid: newUserData.selectedProfile.id,
               userID: newUserData.user.id
@@ -206,11 +207,12 @@ export function tryNativeLauncherProfiles() {
     );
     const { clientToken } = vnlJson;
     const { account } = vnlJson.selectedUser;
-    const { accessToken } = vnlJson.authenticationDatabase[account];
+    const { accessToken, username } = vnlJson.authenticationDatabase[account];
     const newUserData = await refreshAccessToken(accessToken, clientToken, true);
     if (newUserData) {
       const payload = {
-        username: newUserData.selectedProfile.name,
+        email: username,
+        username: newUserData.user.username,
         displayName: newUserData.selectedProfile.name,
         accessToken: newUserData.accessToken,
         uuid: newUserData.selectedProfile.id,


### PR DESCRIPTION
Fixes #256.

EDIT: I should probably explain what's going on here.
Basically, refreshing, and also pulling the logins from the default Minecraft launcher both made it so that the "user" field of the store/config was missing some fields, so I just added them back. 