### PR TITLE
Load Inter font locally

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "fs-extra": "^9.0.0",
     "get-stream": "^5.1.0",
     "history": "^4.10.1",
+    "inter-ui": "^3.13.1",
     "is-electron": "^2.2.0",
     "jarfile": "^2.0.0",
     "jimp": "^0.12.1",

--- a/public/index.html
+++ b/public/index.html
@@ -72,10 +72,6 @@
         }
       })();
     </script>
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap"
-      rel="stylesheet"
-    />
     <script async src="https://www.google-analytics.com/analytics.js"></script>
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,7 @@ import RootElectron from './Root-Electron';
 import ModalsManager from './common/components/ModalsManager';
 
 import 'typeface-roboto';
+import 'inter-ui';
 import ErrorBoundary from './app/desktop/ErrorBoundary';
 
 const Root =

--- a/yarn.lock
+++ b/yarn.lock
@@ -7780,6 +7780,11 @@ insert-css@^2.0.0:
   resolved "https://registry.yarnpkg.com/insert-css/-/insert-css-2.0.0.tgz#eb5d1097b7542f4c79ea3060d3aee07d053880f4"
   integrity sha1-610Ql7dUL0x56jBg067gfQU4gPQ=
 
+inter-ui@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/inter-ui/-/inter-ui-3.13.1.tgz#3b3841c1ab425035d0146b38c7ee7a640d3da3d8"
+  integrity sha512-A+gHBm9WXZZmIYHdQci9ZoIrsPkzwYvWqG2+DyrwOuxjZVnRyz3b73ridPUWI/JvZ1nGf2j0VdJ+vxh0/bKBwg==
+
 internal-ip@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"


### PR DESCRIPTION
I believe some places can't load Google Fonts, or have bad connection to it. This PR adds the font directly into the application via the [`inter-ui`](https://github.com/philipbelesky/inter-ui) NPM package. 