### PR TITLE
[Fix] Preinstall checks with only package.json and .npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "dev": "npm run build-electron:dev && cross-env-shell NODE_ENV=development APP_TYPE=electron BROWSER=none \"npm run start-electron\"",
     "dev-web": "cross-env-shell NODE_ENV=development APP_TYPE=web npm run start",
     "postinstall": "npm run rebuild",
-    "preinstall": "node ./scripts/preinstall.js",
     "rebuild": "node ./scripts/buildNativeDeps.js",
     "deploy": "node ./scripts/createDeploy.js",
     "release:setup": "cross-env-shell NODE_ENV=production APP_TYPE=electron REACT_APP_RELEASE_TYPE=setup \"npm run build\" && npm run build-electron:setup && npm run deploy setup",
@@ -81,6 +80,7 @@
   "engines": {
     "node": ">=14.14.0"
   },
+  "cpu": ["x64"],
   "eslintConfig": {
     "extends": "react-app"
   },

--- a/scripts/preinstall.js
+++ b/scripts/preinstall.js
@@ -1,7 +1,0 @@
-const REQUIRED_NODE_VERSION = 'v14.14.0';
-const REQUIRED_NODE_ARCH = 'x64';
-const NODE_ARCH_VALID = process.arch === REQUIRED_NODE_ARCH;
-
-if (process.version !== REQUIRED_NODE_VERSION || !NODE_ARCH_VALID) {
-  throw new Error(`Please install node ${REQUIRED_NODE_VERSION} x64`);
-}


### PR DESCRIPTION
## Purpose
Fix compatibility with other versions of NodeJS greater than v14.14.0 (current LTS is v14.15.4).

## Approach
Checking version using `"engineVersion"` in `package.json` and `engine-strict` in `.npmrc`.
Using `"cpu"` in `package.json` to restrict architecture to `x64`