### PR TITLE
Add imageURL null check.

### DIFF
--- a/src/common/modals/AddInstance/InstanceName.js
+++ b/src/common/modals/AddInstance/InstanceName.js
@@ -170,7 +170,7 @@ const InstanceName = ({
             localInstanceName,
             loader,
             manifest,
-            `background${path.extname(imageURL)}`
+            imageURL ? `background${path.extname(imageURL)}` : null
           )
         );
       } else if (version?.loaderType === VANILLA) {
@@ -186,7 +186,7 @@ const InstanceName = ({
             localInstanceName,
             loader,
             manifest,
-            `background${path.extname(imageURL)}`
+            imageURL ? `background${path.extname(imageURL)}` : null
           )
         );
       }


### PR DESCRIPTION
## Purpose
Implements the `imageURL` null check on Fabric and Vanilla that's present in Forge.
Patched: [InstanceName.js:173](https://github.com/catgirlyuki/GDLauncher/blob/patch-1/src/common/modals/AddInstance/InstanceName.js#L173) (Fabric Check) [InstanceName.js:189](https://github.com/catgirlyuki/GDLauncher/blob/patch-1/src/common/modals/AddInstance/InstanceName.js#L189) (Vanilla Check)
Original: [InstanceName.js:173](https://github.com/gorilla-devs/GDLauncher/blob/6f7d3a312d3ab685b3f46b7f2349090dae5b72ec/src/common/modals/AddInstance/InstanceName.js#L173) (Fabric Check) [InstanceName.js:189](https://github.com/gorilla-devs/GDLauncher/blob/6f7d3a312d3ab685b3f46b7f2349090dae5b72ec/src/common/modals/AddInstance/InstanceName.js#L189) (Vanilla Check)

## Approach
Just reused the null check from Forge.
Why wasn't this here already?