### PR TITLE
fix minor spelling mistakes in mod sync

### DIFF
--- a/src/common/reducers/actions.js
+++ b/src/common/reducers/actions.js
@@ -2054,7 +2054,7 @@ export const startListener = () => {
       if (queueLength > 1) {
         dispatch(
           updateMessage({
-            content: `Syncronizing mods. ${queueLength} left.`,
+            content: `Synchronizing mods. ${queueLength} left.`,
             duration: 0
           })
         );
@@ -2065,7 +2065,7 @@ export const startListener = () => {
       if (queueLength > 1) {
         dispatch(
           updateMessage({
-            content: `Syncronizing mods. ${queueLength} left.`,
+            content: `Synchronizing mods. ${queueLength} left.`,
             duration: 0
           })
         );


### PR DESCRIPTION
s/syncronizing/synchronizing

## Purpose
The word "synchronizing" was misspelled

## Approach
Corrects the spelling

#### Open Questions and Pre-Merge TODOs
N/A

## Learning
N/A

#### Blog Posts
N/A

