### PR TITLE
Added usual MacOS default menu

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -75,15 +75,35 @@ const edit = [
           label: 'GDLauncher',
           submenu: [
             {
-              label: 'Hide',
-              accelerator: 'Command+H',
-              selector: 'hide:'
+              label: `About GDLauncher`,
+              role: 'about'
             },
             { type: 'separator' },
             {
-              label: 'Quit',
+              label: 'Services',
+              role: 'services',
+              submenu: []
+            },
+            { type: 'separator' },
+            {
+              label: `Hide GDLauncher`,
+              accelerator: 'Command+H',
+              role: 'hide'
+            },
+            {
+              label: 'Hide Others',
+              accelerator: 'Command+Alt+H',
+              role: 'hideOthers'
+            },
+            {
+              label: 'Show All',
+              role: 'unhide'
+            },
+            { type: 'separator' },
+            {
+              label: `Quit GDLauncher`,
               accelerator: 'Command+Q',
-              click: () => {
+              click() {
                 app.quit();
               }
             }

--- a/public/electron.js
+++ b/public/electron.js
@@ -86,7 +86,7 @@ const edit = [
             },
             { type: 'separator' },
             {
-              label: `Hide GDLauncher`,
+              label: 'Hide GDLauncher',
               accelerator: 'Command+H',
               role: 'hide'
             },

--- a/public/electron.js
+++ b/public/electron.js
@@ -101,7 +101,7 @@ const edit = [
             },
             { type: 'separator' },
             {
-              label: `Quit GDLauncher`,
+              label: 'Quit GDLauncher',
               accelerator: 'Command+Q',
               click: () => {
                 app.quit();

--- a/public/electron.js
+++ b/public/electron.js
@@ -75,7 +75,7 @@ const edit = [
           label: 'GDLauncher',
           submenu: [
             {
-              label: `About GDLauncher`,
+              label: 'About GDLauncher',
               role: 'about'
             },
             { type: 'separator' },
@@ -103,7 +103,7 @@ const edit = [
             {
               label: `Quit GDLauncher`,
               accelerator: 'Command+Q',
-              click() {
+              click: () => {
                 app.quit();
               }
             }


### PR DESCRIPTION
New Features:
 - option to open About Page
 - Services Submenu
 - Hide Others
 - Show All

## Purpose
The Mac OS Application Menu has usual a few more options than only to Hide and to Quit the App, like the About window, who shows the Author and the Version of the app and the "Services" submenu to track the task on the Taskmanager (Activity Monitor) and other things. Hope it will be accepted ;) but if not it wasnt that much work. :)
I also added a few pictures to compare before and after:
![Before](https://user-images.githubusercontent.com/76821666/122050335-abe34280-cde3-11eb-8144-6e7887430ec1.png)![After](https://user-images.githubusercontent.com/76821666/122050339-ad146f80-cde3-11eb-8b9e-6967d43589e2.png)
The "Electron" Name of the Menu results on the Developing envoirment, will change to the program name when launched from the app.

#### Open Questions and Pre-Merge TODOs
- [ ] Please **Check the Code** before merging, im not very used to node.js and Electron.

Hope it will be accepted ;) but if not it wasnt that much work. :)
LG Code-Ac aka Acrafts#7503 (on Discord)