### PR TITLE
Parse fabric loader version from modloader ID

### DIFF
--- a/src/common/modals/AddInstance/InstanceName.js
+++ b/src/common/modals/AddInstance/InstanceName.js
@@ -158,10 +158,17 @@ const InstanceName = ({
           )
         );
       } else if (version?.loaderType === FABRIC) {
+        // Backwards compatability for manifest entries that use the `yarn`
+        // property to set the fabric loader version. Newer manifests use the
+        // format `fabric-<version>` in the id.
+        let loaderVersion = manifest.minecraft.modLoaders[0].yarn;
+        if (!loaderVersion) {
+          loaderVersion = manifest.minecraft.modLoaders[0].id.split('-', 2)[1];
+        }
         const loader = {
           loaderType: version?.loaderType,
           mcVersion: manifest.minecraft.version,
-          loaderVersion: manifest.minecraft.modLoaders[0].yarn,
+          loaderVersion,
           fileID: manifest.minecraft.modLoaders[0].loader,
           projectID: version?.projectID,
           source: version?.source

--- a/src/common/modals/InstanceExport/CurseForge/ThirdStep.js
+++ b/src/common/modals/InstanceExport/CurseForge/ThirdStep.js
@@ -72,8 +72,7 @@ export default function ThirdStep({
         break;
       case FABRIC:
         loaderObj = {
-          id: modloaderName,
-          yarn: loader?.loaderVersion,
+          id: `${modloaderName}-${loader?.loaderVersion}`,
           loader: loader?.fileID,
           primary: true
         };


### PR DESCRIPTION
## Purpose

CurseForge doesn't (or no longer) uses the yarn property in the manifest to specify the fabric version. Instead they now include the version in id property, ex: `fabric-0.11.6`.

See #942 

## Approach

When importing an instance via zip we'll check for the `yarn` property in the manifest first, for backwards compatibility, but will then try to extract it from the `id` if it's missing.

For exporting we'll now include the loader version in the `id` and omit the `yarn` property, exactly like CurseForge.

**Note:** this means exporting is _not_ backwards compatible.

## Learning

To implement this I compared manifests by downloading fabric-based modpacks from CurseForge (ex. [All of Fabric 4](https://www.curseforge.com/minecraft/modpacks/all-of-fabric-4) as well as exports of a fresh fabric instance from within GDLauncher.

## Testing

I tested the implementation by ensuring all of these scenarios worked:

1. [All of Fabric 4](https://www.curseforge.com/minecraft/modpacks/all-of-fabric-4) zip can be imported
2. Create a Fabric instance using an unpatched GDLauncher, export it, and then import it back into the patched version
3. Create a Fabric instance using a patched GDLauncher, export it, and then import it back into the patched version
