### PR TITLE
Increase Maximum Value on Memory Sliders 

### DIFF
--- a/src/common/modals/InstanceManager/Overview.js
+++ b/src/common/modals/InstanceManager/Overview.js
@@ -119,7 +119,8 @@ const marks = {
   2048: '2048 MB',
   4096: '4096 MB',
   8192: '8192 MB',
-  16384: '16384 MB'
+  16384: '16384 MB',
+  32768: '32768 MB'
 };
 
 const Card = memo(
@@ -494,7 +495,7 @@ const Overview = ({ instanceName, background, manifest }) => {
                 onChange={setJavaLocalMemory}
                 value={javaLocalMemory}
                 min={1024}
-                max={16384}
+                max={32768}
                 step={512}
                 marks={marks}
                 valueLabelDisplay="auto"

--- a/src/common/modals/Settings/components/Java.js
+++ b/src/common/modals/Settings/components/Java.js
@@ -102,7 +102,8 @@ const marks = {
   2048: '2048 MB',
   4096: '4096 MB',
   8192: '8192 MB',
-  16384: '16384 MB'
+  16384: '16384 MB',
+  32768: '32768 MB'
 };
 
 export default function MyAccountPreferences() {
@@ -309,7 +310,7 @@ export default function MyAccountPreferences() {
           }}
           defaultValue={javaMemory}
           min={1024}
-          max={16384}
+          max={32768}
           step={512}
           marks={marks}
           valueLabelDisplay="auto"


### PR DESCRIPTION
## Purpose
This PR adds an extra mark on the memory slider to allow users to set the memory to 32768 MB. It also partially solves #872.

## Approach
This change adds an extra mark to the slider on both the instance page and the global Java settings.
