### PR TITLE
Fixed Problem whit hidden accounts in modal

### DIFF
--- a/src/common/modals/AccountsManager.js
+++ b/src/common/modals/AccountsManager.js
@@ -33,12 +33,7 @@ const ProfileSettings = () => {
       title="Account Manager"
     >
       <Container>
-        <AccountsContainer
-          css={`
-            overflow: auto;
-            padding-right: 2px;
-          `}
-        >
+        <AccountsContainer>
           {accounts.map(account => {
             if (!account || !currentAccount) return;
             return (
@@ -202,6 +197,8 @@ const HoverContainer = styled.div`
 const AccountsContainer = styled.div`
   width: 100%;
   height: 100%;
+  overflow: auto;
+  padding-right: 2px;
 `;
 
 const AccountContainer = styled.div`

--- a/src/common/modals/AccountsManager.js
+++ b/src/common/modals/AccountsManager.js
@@ -33,7 +33,12 @@ const ProfileSettings = () => {
       title="Account Manager"
     >
       <Container>
-        <AccountsContainer>
+        <AccountsContainer
+          css={`
+            overflow: auto;
+            padding-right: 2px;
+          `}
+        >
           {accounts.map(account => {
             if (!account || !currentAccount) return;
             return (


### PR DESCRIPTION
We had someone on Discord tonight who contacted us about a problem in the Account Modal. He had so many Minecraft accounts that they overlaped on the bottom of the modal and caused some weird problems whit the css.

## Purpose
Fixing the not showing accounts as well as the "Add account" button who in result of this moved down out of the Modal.

## Approach
1. Added a `css` attribute to the parent element of the account
2. Added `overflow:auto` to override the css atribute to override previous `overflow:hidden`. This causes the overflowing elements to no longer hide like before but a scroolbar to appear on the right side of the Modal to scroll down and see the other elemts in the list.
3. Added  `padding-right: 2px` to the css attribute to make place for the now possible scrollbar, otherwise it would overlap whit the Trash-Icons on the right. 

#### Open Questions and Pre-Merge TODOs
- [ ] Please test it on Windows, I can work whit css quite well but I am working on MacOS (its doing weird style changes sometimes)
- [x] Test on MacOS

## Result 
Just duplicated my account whit the browsers dev tools
#### Before
![Bildschirmfoto 2021-06-22 um 22 19 07](https://user-images.githubusercontent.com/76821666/122993707-e92d6e80-d3a7-11eb-95b4-d4a9bacdc57a.png)
#### After
![Bildschirmfoto 2021-06-22 um 22 07 54](https://user-images.githubusercontent.com/76821666/122993704-e894d800-d3a7-11eb-8c6e-c549c39df99d.png)