### PR TITLE
[Inconsitency] Concurrent downloads setting not used whit ftb modpacks | Better progress update

### DIFF
--- a/src/common/reducers/actions.js
+++ b/src/common/reducers/actions.js
@@ -1527,10 +1527,10 @@ export function processFTBManifest(instanceName) {
 
     dispatch(updateDownloadStatus(instanceName, 'Downloading FTB files...'));
     await downloadInstanceFiles(
-        mappedFiles,
-        updatePercentage,
-        state.settings.concurrentDownloads
-        );
+      mappedFiles,
+      updatePercentage,
+      state.settings.concurrentDownloads
+    );
 
     mappedFiles = await pMap(
       files,

--- a/src/common/reducers/actions.js
+++ b/src/common/reducers/actions.js
@@ -1508,8 +1508,14 @@ export function processFTBManifest(instanceName) {
 
     let modManifests = [];
 
+    let prev = 0;
     const updatePercentage = downloaded => {
-      dispatch(updateDownloadProgress((downloaded * 100) / files.length));
+      const percentage = (downloaded * 100) / files.length;
+      const progress = parseInt(percentage, 10);
+      if (progress !== prev) {
+        prev = progress;
+        dispatch(updateDownloadProgress(progress));
+      }
     };
 
     let mappedFiles = files.map(async item => {

--- a/src/common/reducers/actions.js
+++ b/src/common/reducers/actions.js
@@ -1526,7 +1526,11 @@ export function processFTBManifest(instanceName) {
     });
 
     dispatch(updateDownloadStatus(instanceName, 'Downloading FTB files...'));
-    await downloadInstanceFiles(mappedFiles, updatePercentage);
+    await downloadInstanceFiles(
+        mappedFiles,
+        updatePercentage,
+        state.settings.concurrentDownloads
+        );
 
     mappedFiles = await pMap(
       files,


### PR DESCRIPTION
## Purpose
While trying to fix another Bug, I found two little inconcistencys in the code to Download  the FTB Modpacks
- The concurrent downloads setting was not passed to the function, resulting in a default of 4.
- The function `updatePercentage` was whitout a reason not the same as for all the other instance download options, resulting in a way higher cpu load (multiple thousand GUI updates instead of 100 for every percentage) and a loss of the `parseInt` call which I guess is there for errorcatching

## Approach
- Added `state.settings.concurrentDownloads` argument to pass to the `downloadInstanceFiles` function.
- Integrated the `updatePercentage` function from the other instancedownload options.
<br/>
For more information read the comit messages or write a comment ;)