### PR TITLE
Typo in screenshot.js

### DIFF
--- a/src/common/modals/InstanceManager/Screenshots.js
+++ b/src/common/modals/InstanceManager/Screenshots.js
@@ -216,7 +216,7 @@ const Screenshots = ({ instanceName }) => {
             if (selectedItems.length) {
               dispatch(
                 openModal('ActionConfirmation', {
-                  message: 'Are you sure you want to delete this images?',
+                  message: 'Are you sure you want to delete this image(s)?',
                   confirmCallback: deleteFile,
                   title: 'Confirm'
                 })


### PR DESCRIPTION
## Purpose
This is a typo error.

## Approach
It changes the problem because I fixed the typo error

## Learning
_Links to blog posts, patterns, libraries or addons used to solve this problem_ : Nothing because it is not a code error.
