### PR TITLE
Limited memory sliders to max system memory

### DIFF
--- a/src/common/modals/InstanceManager/Overview.js
+++ b/src/common/modals/InstanceManager/Overview.js
@@ -495,7 +495,7 @@ const Overview = ({ instanceName, background, manifest }) => {
                 onChange={setJavaLocalMemory}
                 value={javaLocalMemory}
                 min={1024}
-                max={32768}
+                max={process.getSystemMemoryInfo().total / 1000}
                 step={512}
                 marks={marks}
                 valueLabelDisplay="auto"

--- a/src/common/modals/Settings/components/Java.js
+++ b/src/common/modals/Settings/components/Java.js
@@ -311,7 +311,7 @@ export default function MyAccountPreferences() {
           }}
           defaultValue={javaMemory}
           min={1024}
-          max={32768}
+          max={process.getSystemMemoryInfo().total / 1000}
           step={512}
           marks={marks}
           valueLabelDisplay="auto"


### PR DESCRIPTION
## Purpose
Cleaning up the mess on my screen (see below)

## Approach
Used the `process.getSystemMemoryInfo().total` property to limit sliders. Self-explaining.

## How it looks
### Before
![Bildschirmfoto 2021-06-26 um 22 38 39](https://user-images.githubusercontent.com/76821666/123525214-4b031680-d6cf-11eb-9f51-63439a692ac5.png)
### After
![Bildschirmfoto 2021-06-26 um 22 31 04](https://user-images.githubusercontent.com/76821666/123525211-4a6a8000-d6cf-11eb-8039-4f6dcb52841d.png)