### PR TITLE
Auto-detect CurseForge modpack loader type

### DIFF
--- a/src/app/desktop/utils/index.js
+++ b/src/app/desktop/utils/index.js
@@ -872,6 +872,17 @@ export const getFilesRecursive = async dir => {
   return files.reduce((a, f) => a.concat(f), []);
 };
 
+export const extractFabricVersionFromManifest = manifest => {
+  // Backwards compatability for manifest entries that use the `yarn`
+  // property to set the fabric loader version. Newer manifests use the
+  // format `fabric-<version>` in the id.
+  let loaderVersion = manifest?.minecraft?.modLoaders[0]?.yarn;
+  if (!loaderVersion) {
+    loaderVersion = manifest?.minecraft?.modLoaders[0]?.id?.split('-', 2)[1];
+  }
+  return loaderVersion;
+};
+
 export const convertcurseForgeToCanonical = (
   curseForge,
   mcVersion,

--- a/src/common/modals/AddInstance/CurseForgeModpacks/ModpacksListWrapper.js
+++ b/src/common/modals/AddInstance/CurseForgeModpacks/ModpacksListWrapper.js
@@ -6,7 +6,7 @@ import InfiniteLoader from 'react-window-infinite-loader';
 import ContentLoader from 'react-content-loader';
 import { transparentize } from 'polished';
 import { openModal } from '../../../reducers/modals/actions';
-import { FORGE, CURSEFORGE } from '../../../utils/constants';
+import { CURSEFORGE } from '../../../utils/constants';
 
 const ModpacksListWrapper = ({
   // Are there more items to load?
@@ -86,7 +86,6 @@ const ModpacksListWrapper = ({
           <div
             onClick={() => {
               setVersion({
-                loaderType: FORGE,
                 projectID: modpack.id,
                 fileID: modpack.latestFiles[modpack.latestFiles.length - 1].id,
                 source: CURSEFORGE

--- a/src/common/modals/AddInstance/InstanceName.js
+++ b/src/common/modals/AddInstance/InstanceName.js
@@ -18,7 +18,8 @@ import { closeModal, openModal } from '../../reducers/modals/actions';
 import {
   downloadAddonZip,
   importAddonZip,
-  convertcurseForgeToCanonical
+  convertcurseForgeToCanonical,
+  extractFabricVersionFromManifest,
 } from '../../../app/desktop/utils';
 import { _getInstancesPath, _getTempPath } from '../../utils/selectors';
 import bgImage from '../../assets/mcCube.jpg';
@@ -100,13 +101,12 @@ const InstanceName = ({
 
     const initTimestamp = Date.now();
 
-    const isVanilla = version?.loaderType === VANILLA;
-    const isFabric = version?.loaderType === FABRIC;
-    const isForge = version?.loaderType === FORGE;
     const isCurseForgeModpack = Boolean(modpack?.attachments);
     const isFTBModpack = Boolean(modpack?.art);
     let manifest;
 
+    // If it's a curseforge modpack grab the manfiest and detect the loader
+    // type as we don't yet know what it is.
     if (isCurseForgeModpack) {
       if (importZipPath) {
         manifest = await importAddonZip(
@@ -132,13 +132,20 @@ const InstanceName = ({
         v => v.id.includes(FABRIC) && v.primary
       );
 
-      let curseForgeLoaderType = VANILLA;
       if (isForgeModpack) {
-        curseForgeLoaderType = FORGE;
+        version.loaderType = FORGE;
       } else if (isFabricModpack) {
-        curseForgeLoaderType = FABRIC;
+        version.loaderType = FABRIC;
+      } else {
+        version.loaderType = VANILLA;
       }
+    }
 
+    const isVanilla = version?.loaderType === VANILLA;
+    const isFabric = version?.loaderType === FABRIC;
+    const isForge = version?.loaderType === FORGE;
+
+    if (isCurseForgeModpack) {
       if (imageURL) {
         await downloadFile(
           path.join(
@@ -150,9 +157,9 @@ const InstanceName = ({
         );
       }
 
-      if (curseForgeLoaderType === FORGE) {
+      if (isForge) {
         const loader = {
-          loaderType: curseForgeLoaderType,
+          loaderType: FORGE,
           mcVersion: manifest.minecraft.version,
           loaderVersion: convertcurseForgeToCanonical(
             manifest.minecraft.modLoaders.find(v => v.primary).id,
@@ -172,19 +179,12 @@ const InstanceName = ({
             imageURL ? `background${path.extname(imageURL)}` : null
           )
         );
-      } else if (curseForgeLoaderType === FABRIC) {
-        // Backwards compatability for manifest entries that use the `yarn`
-        // property to set the fabric loader version. Newer manifests use the
-        // format `fabric-<version>` in the id.
-        let loaderVersion = manifest.minecraft.modLoaders[0].yarn;
-        if (!loaderVersion) {
-          loaderVersion = manifest.minecraft.modLoaders[0].id.split('-', 2)[1];
-        }
+      } else if (isFabric) {
         const loader = {
-          loaderType: curseForgeLoaderType,
+          loaderType: FABRIC,
           mcVersion: manifest.minecraft.version,
-          loaderVersion,
-          fileID: manifest.minecraft.modLoaders[0].loader,
+          loaderVersion: extractFabricVersionFromManifest(manifest),
+          fileID: version?.fileID,
           projectID: version?.projectID,
           source: version?.source
         };
@@ -196,9 +196,9 @@ const InstanceName = ({
             imageURL ? `background${path.extname(imageURL)}` : null
           )
         );
-      } else if (curseForgeLoaderType === VANILLA) {
+      } else if (isVanilla) {
         const loader = {
-          loaderType: curseForgeLoaderType,
+          loaderType: VANILLA,
           mcVersion: manifest.minecraft.version,
           loaderVersion: version?.loaderVersion,
           fileID: version?.fileID

--- a/src/common/modals/AddInstance/InstanceName.js
+++ b/src/common/modals/AddInstance/InstanceName.js
@@ -124,6 +124,21 @@ const InstanceName = ({
         );
       }
 
+      const isForgeModpack = (manifest?.minecraft?.modLoaders || []).some(
+        v => v.id.includes(FORGE) && v.primary
+      );
+
+      const isFabricModpack = (manifest?.minecraft?.modLoaders || []).some(
+        v => v.id.includes(FABRIC) && v.primary
+      );
+
+      let curseForgeLoaderType = VANILLA;
+      if (isForgeModpack) {
+        curseForgeLoaderType = FORGE;
+      } else if (isFabricModpack) {
+        curseForgeLoaderType = FABRIC;
+      }
+
       if (imageURL) {
         await downloadFile(
           path.join(
@@ -135,9 +150,9 @@ const InstanceName = ({
         );
       }
 
-      if (version?.loaderType === FORGE) {
+      if (curseForgeLoaderType === FORGE) {
         const loader = {
-          loaderType: version?.loaderType,
+          loaderType: curseForgeLoaderType,
           mcVersion: manifest.minecraft.version,
           loaderVersion: convertcurseForgeToCanonical(
             manifest.minecraft.modLoaders.find(v => v.primary).id,
@@ -157,7 +172,7 @@ const InstanceName = ({
             imageURL ? `background${path.extname(imageURL)}` : null
           )
         );
-      } else if (version?.loaderType === FABRIC) {
+      } else if (curseForgeLoaderType === FABRIC) {
         // Backwards compatability for manifest entries that use the `yarn`
         // property to set the fabric loader version. Newer manifests use the
         // format `fabric-<version>` in the id.
@@ -166,7 +181,7 @@ const InstanceName = ({
           loaderVersion = manifest.minecraft.modLoaders[0].id.split('-', 2)[1];
         }
         const loader = {
-          loaderType: version?.loaderType,
+          loaderType: curseForgeLoaderType,
           mcVersion: manifest.minecraft.version,
           loaderVersion,
           fileID: manifest.minecraft.modLoaders[0].loader,
@@ -181,9 +196,9 @@ const InstanceName = ({
             imageURL ? `background${path.extname(imageURL)}` : null
           )
         );
-      } else if (version?.loaderType === VANILLA) {
+      } else if (curseForgeLoaderType === VANILLA) {
         const loader = {
-          loaderType: version?.loaderType,
+          loaderType: curseForgeLoaderType,
           mcVersion: manifest.minecraft.version,
           loaderVersion: version?.loaderVersion,
           fileID: version?.fileID

--- a/src/common/reducers/actions.js
+++ b/src/common/reducers/actions.js
@@ -101,7 +101,8 @@ import {
   getPatchedInstanceType,
   convertCompletePathToInstance,
   downloadAddonZip,
-  convertcurseForgeToCanonical
+  convertcurseForgeToCanonical,
+  extractFabricVersionFromManifest
 } from '../../app/desktop/utils';
 import {
   downloadFile,
@@ -1989,14 +1990,21 @@ export const changeModpackVersion = (instanceName, newModpackData) => {
         imageURL
       );
 
-      const loader = {
-        loaderType: instance.loader?.loaderType,
-        mcVersion: newManifest.minecraft.version,
-        loaderVersion: convertcurseForgeToCanonical(
+      let loaderVersion;
+      if (instance.loader?.loaderType === FABRIC) {
+        loaderVersion = extractFabricVersionFromManifest(newManifest);
+      } else {
+        loaderVersion = convertcurseForgeToCanonical(
           newManifest.minecraft.modLoaders.find(v => v.primary).id,
           newManifest.minecraft.version,
           state.app.forgeManifest
-        ),
+        );
+      }
+
+      const loader = {
+        loaderType: instance.loader?.loaderType,
+        mcVersion: newManifest.minecraft.version,
+        loaderVersion,
         fileID: instance.loader?.fileID,
         projectID: instance.loader?.projectID,
         source: instance.loader?.source


### PR DESCRIPTION
## Purpose
Currently all CurseForge modpacks are assumed to be using Forge, whereas they may actually be using Fabric. Instead of hardcoding which one is being used, we can parse the type from the manifest.

See #961

## Approach

When the manifest is downloaded from CurseForge we will now detect which loader is being used from the ID.

I'm not entirely happy with how this is wired up though as this function is now very convoluted and things are defined multiple times. A refactor is likely needed here to breakup instance creation to enable more code reuse.

## Learning

 - When importing from CurseForge the loaderType is hard coded: https://github.com/gorilla-devs/GDLauncher/blob/67e61cc76c36d4e17caf61346ef641f013870448/src/common/modals/AddInstance/CurseForgeModpacks/ModpacksListWrapper.js#L89
 - The logic for parsing which loader type is being used based on the manifest is coped from: https://github.com/gorilla-devs/GDLauncher/blob/67e61cc76c36d4e17caf61346ef641f013870448/src/common/modals/AddInstance/Import.js#L107-L113
