### PR TITLE
Fix for Beta Channel not working

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6770,7 +6770,8 @@
     "ci-info": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.2.0.tgz",
-      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A=="
+      "integrity": "sha512-dVqRX7fLUm8J6FgHJ418XuIgDLZDkYcDFTeL6TA2gt5WlIZUQrrH6EZrNClwT/H0FateUsZkGIOPRrLbP+PR9A==",
+      "dev": true
     },
     "cipher-base": {
       "version": "1.0.4",

--- a/src/common/modals/ChangeLogs.js
+++ b/src/common/modals/ChangeLogs.js
@@ -38,8 +38,7 @@ const data = {
     },
     {
       header: 'You can now easily duplicate instances.',
-      content:
-        'Just right-click on an instance and duplicate it 😃.'
+      content: 'Just right-click on an instance and duplicate it 😃.'
     }
   ],
   improvements: [

--- a/src/common/modals/Settings/components/General.js
+++ b/src/common/modals/Settings/components/General.js
@@ -391,7 +391,7 @@ const General = () => {
               setReleaseChannel(e);
               await fsa.writeFile(
                 path.join(appData, 'gdlauncher_next', 'rChannel'),
-                e
+                e.toString()
               );
             }}
             value={releaseChannel}


### PR DESCRIPTION
## Purpose
This PR fixes an issue with node.js failing to write integers to a file using `fsa.writeFile`, even though it should be able to accept any type of data. This allows the Beta channel to once again work. (This honestly feels like such a dumb PR, but it appeared to be such a dumb issue)

I tested it by lowering the version number of my local build, and tried with both the setup and portable launcher and both correctly updated from both release channels

And then I also fixed some formatting in the Changelog dialog that eslint was yelling about and that was not allowing me to commit
