### PR TITLE
Fix for Java Dialog Popping up Constantly

### DIFF
--- a/src/app/desktop/DesktopRoot.js
+++ b/src/app/desktop/DesktopRoot.js
@@ -80,15 +80,22 @@ function DesktopRoot({ store }) {
     let isJava8OK = javaPath;
     let isJava16Ok = java16Path;
 
-    if (!javaPath?.isValid) {
+    if (!isJava8OK) {
       isJava8OK = await isLatestJavaDownloaded(manifests, userData, true);
     }
 
-    if (!java16Path?.isValid) {
+    if (!isJava16Ok) {
       isJava16Ok = await isLatestJavaDownloaded(manifests, userData, true, 16);
     }
 
-    if (!isJava8OK?.isValid || !isJava16Ok?.isValid) {
+    if (
+      (typeof isJava8OK === 'string'
+        ? isJava8OK.isEmpty
+        : !isJava8OK.isValid) ||
+      (typeof isJava16Ok === 'string'
+        ? isJava16Ok.isEmpty
+        : !isJava16Ok.isValid)
+    ) {
       dispatch(openModal('JavaSetup', { preventClose: true }));
 
       // Super duper hacky solution to await the modal to be closed...
@@ -184,7 +191,7 @@ function DesktopRoot({ store }) {
         <RouteBackground />
         <Switch>
           {routes.map((route, i) => (
-            <RouteWithSubRoutes key={i} {...route} /> // eslint-disable-line
+                <RouteWithSubRoutes key={i} {...route} /> // eslint-disable-line
           ))}
         </Switch>
       </Container>

--- a/src/common/modals/ChangeLogs.js
+++ b/src/common/modals/ChangeLogs.js
@@ -38,8 +38,7 @@ const data = {
     },
     {
       header: 'You can now easily duplicate instances.',
-      content:
-        'Just right-click on an instance and duplicate it 😃.'
+      content: 'Just right-click on an instance and duplicate it 😃.'
     }
   ],
   improvements: [


### PR DESCRIPTION
## Purpose
This fixes a bug from the Java 16 support that causes the java setup dialog to constantly pop-up when you open the launcher, even when the setup is complete
