### PR TITLE
Fix wording and puncutation of settings descriptions.

### DIFF
--- a/src/common/modals/Settings/components/General.js
+++ b/src/common/modals/Settings/components/General.js
@@ -348,7 +348,7 @@ const General = () => {
       <Content>
         <p>
           Select the number of concurrent downloads. If you have a slow
-          connection, select at max 3.
+          connection, select at most 3.
         </p>
         <Select
           onChange={v => dispatch(updateConcurrentDownloads(v))}
@@ -483,8 +483,8 @@ const General = () => {
       </Title>
       <Content>
         <p>
-          Deletes all the shared files between instances. Doing this will result
-          in the complete loss of the instances data.
+          Deletes all the shared files between instances. Doing this will remove
+          ALL instance data.
         </p>
         <Button
           onClick={() => {

--- a/src/common/modals/Settings/components/General.js
+++ b/src/common/modals/Settings/components/General.js
@@ -320,8 +320,8 @@ const General = () => {
       <Title>Release Channel</Title>
       <Content>
         <p>
-          Stable updates once a month. Beta updates more often, but it may
-          have more bugs.
+          Stable updates once a month. Beta updates more often, but it may have
+          more bugs.
         </p>
         <Select
           css={`

--- a/src/common/modals/Settings/components/General.js
+++ b/src/common/modals/Settings/components/General.js
@@ -320,7 +320,7 @@ const General = () => {
       <Title>Release Channel</Title>
       <Content>
         <p>
-          Stable updates once a month, beta does update more often but it may
+          Stable updates once a month. Beta updates more often, but it may
           have more bugs.
         </p>
         <Select
@@ -348,7 +348,7 @@ const General = () => {
       <Content>
         <p>
           Select the number of concurrent downloads. If you have a slow
-          connection, select max 3
+          connection, select at max 3.
         </p>
         <Select
           onChange={v => dispatch(updateConcurrentDownloads(v))}
@@ -400,7 +400,7 @@ const General = () => {
       <Content>
         <p>
           Select the preferred release channel for downloading Curse projects.
-          This also applies for mods update.
+          This also applies for mod updates.
         </p>
         <Select
           css={`
@@ -454,7 +454,7 @@ const General = () => {
       <Content>
         <p>
           Automatically hide the launcher when launching an instance. You will
-          still be able to open it from the icon tray
+          still be able to open it from the icon tray.
         </p>
         <Switch
           onChange={e => {
@@ -469,7 +469,7 @@ const General = () => {
       <Content>
         <p>
           You got a potato PC? Don&apos;t worry! We got you covered. Enable this
-          and all animations and special effects will be disabled
+          and all animations and special effects will be disabled.
         </p>
         <Switch
           onChange={e => {
@@ -484,7 +484,7 @@ const General = () => {
       <Content>
         <p>
           Deletes all the shared files between instances. Doing this will result
-          in the complete loss of the instances data
+          in the complete loss of the instances data.
         </p>
         <Button
           onClick={() => {
@@ -606,8 +606,8 @@ const General = () => {
         </div>
         <p>
           {updateAvailable
-            ? 'There is an update available to be installed. Click on update to install it and restart the launcher'
-            : 'You’re currently on the latest version. We automatically check for updates and we will inform you whenever one is available'}
+            ? 'There is an update available to be installed. Click on update to install it and restart the launcher.'
+            : 'You’re currently on the latest version. We automatically check for updates and we will inform you whenever one is available.'}
         </p>
         <div
           css={`

--- a/src/common/modals/Settings/components/Java.js
+++ b/src/common/modals/Settings/components/Java.js
@@ -170,7 +170,7 @@ export default function MyAccountPreferences() {
           `}
         >
           Disable this to specify a custom java path to use instead of using
-          openJDK shipped with GDLauncher if that is the case select the path to
+          OpenJDK shipped with GDLauncher. If that is the case, select the path to
           your Java executable.
         </Paragraph>
         <Switch
@@ -315,7 +315,7 @@ export default function MyAccountPreferences() {
             margin: 0;
           `}
         >
-          Select the initial game resolution in pixels (width x height)
+          Select the initial game resolution in pixels (width x height).
         </Paragraph>
         <ResolutionInputContainer>
           <div>
@@ -385,7 +385,7 @@ export default function MyAccountPreferences() {
             margin: 0;
           `}
         >
-          Select the preferred amount of memory to use when launching the game
+          Select the preferred amount of memory to use when launching the game.
         </Paragraph>
         <Slider
           css={`
@@ -417,7 +417,7 @@ export default function MyAccountPreferences() {
             text-align: left;
           `}
         >
-          Select the preferred custom arguments to use when launching the game
+          Select the preferred custom arguments to use when launching the game.
         </Paragraph>
         <div
           css={`

--- a/src/common/modals/Settings/components/Java.js
+++ b/src/common/modals/Settings/components/Java.js
@@ -170,8 +170,8 @@ export default function MyAccountPreferences() {
           `}
         >
           Disable this to specify a custom java path to use instead of using
-          OpenJDK shipped with GDLauncher. If that is the case, select the path to
-          your Java executable.
+          OpenJDK shipped with GDLauncher. If that is the case, select the path
+          to your Java executable.
         </Paragraph>
         <Switch
           color="primary"


### PR DESCRIPTION
## Purpose
Settings menu descriptions were inconsistently punctuated, as well as awkwardly worded.

## Approach
Add periods to ends of all sentences, as well as reword slightly.

#### Open Questions and Pre-Merge TODOs
- [ ] Is "select" the correct word for game resolution, JVM memory, and JVM args?
