### PR TITLE
Initial implementation of open export folder

### DIFF
--- a/src/common/modals/InstanceExport/CurseForge/ThirdStep.js
+++ b/src/common/modals/InstanceExport/CurseForge/ThirdStep.js
@@ -46,6 +46,7 @@ export default function ThirdStep({
   instancesPath,
   instanceConfig,
   filePath, // Destionation path for zip
+  openExportFolder,
   packVersion,
   tempPath,
   packAuthor,
@@ -284,6 +285,17 @@ export default function ThirdStep({
                           `}
                         />
                       </h1>
+                      <div>
+                        <Button
+                          type="primary"
+                          onClick={openExportFolder}
+                          css={`
+                            margin-top: 20px;
+                          `}
+                        >
+                          Open Export Folder
+                        </Button>
+                      </div>
                       <div>
                         <Button
                           type="primary"

--- a/src/common/modals/InstanceExport/CurseForge/ThirdStep.js
+++ b/src/common/modals/InstanceExport/CurseForge/ThirdStep.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useDispatch } from 'react-redux';
+import { ipcRenderer } from 'electron';
 import { Button } from 'antd';
 import path from 'path';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -46,7 +47,6 @@ export default function ThirdStep({
   instancesPath,
   instanceConfig,
   filePath, // Destionation path for zip
-  openExportFolder,
   packVersion,
   tempPath,
   packAuthor,
@@ -62,6 +62,10 @@ export default function ThirdStep({
   const modloaderName = loader?.loaderType;
   const dispatch = useDispatch();
   const tempExport = path.join(tempPath, instanceName);
+
+  const openExportLocation = async () => {
+    await ipcRenderer.invoke('openFolder', filePath);
+  };
 
   // Construct manifest contents
   const createManifest = async (modsArray = mods) => {
@@ -288,12 +292,12 @@ export default function ThirdStep({
                       <div>
                         <Button
                           type="primary"
-                          onClick={openExportFolder}
+                          onClick={openExportLocation}
                           css={`
                             margin-top: 20px;
                           `}
                         >
-                          Open Export Folder
+                          Open Export Location
                         </Button>
                       </div>
                       <div>

--- a/src/common/modals/InstanceExport/CurseForge/index.js
+++ b/src/common/modals/InstanceExport/CurseForge/index.js
@@ -38,6 +38,10 @@ const InstanceExportCurseForge = ({ instanceName }) => {
     setFilePath(dialog.filePaths[0]);
   };
 
+  const openExportFolder = async () => {
+    await ipcRenderer.invoke('openFolder', filePath);
+  };
+
   return (
     <Modal
       css={`
@@ -78,6 +82,7 @@ const InstanceExportCurseForge = ({ instanceName }) => {
       <ThirdStep
         packZipName={packZipName}
         filePath={filePath}
+        openExportFolder={openExportFolder}
         page={page}
         instanceName={instanceName}
         instanceConfig={instanceConfig}

--- a/src/common/modals/InstanceExport/CurseForge/index.js
+++ b/src/common/modals/InstanceExport/CurseForge/index.js
@@ -38,10 +38,6 @@ const InstanceExportCurseForge = ({ instanceName }) => {
     setFilePath(dialog.filePaths[0]);
   };
 
-  const openExportFolder = async () => {
-    await ipcRenderer.invoke('openFolder', filePath);
-  };
-
   return (
     <Modal
       css={`
@@ -82,7 +78,6 @@ const InstanceExportCurseForge = ({ instanceName }) => {
       <ThirdStep
         packZipName={packZipName}
         filePath={filePath}
-        openExportFolder={openExportFolder}
         page={page}
         instanceName={instanceName}
         instanceConfig={instanceConfig}


### PR DESCRIPTION
## Purpose
After exporting an instance, you often have to travel to the location where you exported it again, unless you already had it open.

## Approach
The PR adds an extra button to the last step of the Export Instance dialogue that opens the folder that contains the exported pack.

![Preview:](https://user-images.githubusercontent.com/20760920/134783035-6431e5a6-0591-482b-af9d-e719e12ee80e.png)

#### Open Questions and Pre-Merge TODOs
- [ ] Formatting is WIP, please suggest any improvements.
- [ ] Button seems to stay highlighted after clicking it, not sure if this is an electron bug, or something wrong with my implementation.
- [ ] Consider a setting which may automatically open the folder after exporting any pack.

## Learning
I just looked at the existing code and just tried my best :)