### PR TITLE
Update electron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8712,9 +8712,9 @@
       }
     },
     "electron": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-14.0.1.tgz",
-      "integrity": "sha512-1XILvfE5mQEBz5L/QeNfcwC3PxAIjwMyA3GR8Naw5C0IKAnHl3lAdjczbtGX8nqbcEpOAVo+4TMSpcPD3zxe8Q==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-14.1.0.tgz",
+      "integrity": "sha512-MnZSITjtdrY6jM/z/qXcuJqbIvz7MbxHp9f1O93mq/vt7aTxHYgjerPSqwya/RoUjkPEm1gkz669FsRk6ZtMdQ==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -11318,9 +11318,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.17.3",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.17.3.tgz",
-          "integrity": "sha512-lyvajs+wd8N1hXfzob1LdOCCHFU4bGMbqqmLn1Q4QlCpDqWPpGf+p0nj+LNrvDDG33j0hZXw2nsvvVpHysxyNw==",
+          "version": "3.18.1",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.18.1.tgz",
+          "integrity": "sha512-vJlUi/7YdlCZeL6fXvWNaLUPh/id12WXj3MbkMw5uOyF0PfWPBNOCNbs53YqgrvtujLNlt9JQpruyIKkUZ+PKA==",
           "dev": true,
           "optional": true
         }

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "concurrently": "^6.2.1",
     "cross-env": "^7.0.3",
     "dotenv": "^10.0.0",
-    "electron": "^14.0.1",
+    "electron": "^14.1.0",
     "electron-builder": "^22.11.7",
     "eslint": "^7.32.0",
     "eslint-config-airbnb": "^18.2.1",
@@ -144,8 +144,8 @@
     "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "7zip-bin": "^5.1.1",
     "@loadable/babel-plugin": "^5.13.2",
+    "7zip-bin": "^5.1.1",
     "antd": "4.16.11",
     "axios": "^0.21.1",
     "base64-stream": "^1.0.0",


### PR DESCRIPTION
## Purpose
Fixes forge installer not downloading in #1086 

## Approach
Updates electron to a version with the fix for not allowing for the let's encrypt root CA

## Learning
Read the article on let's encrypt's website and the announcement from forge. Searched the electron github repository for issue's mentioning the let's encrypt root CA and found https://github.com/electron/electron/issues/31212 which mentions that a fix was released
