### PR TITLE
fix incorrect benchmark times

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ GDLauncher is a custom open-source Minecraft launcher written from the ground up
 
 This is an example of the time that GDLauncher takes to install a modpack in comparison to Twitch. Both tests are running at the same time over a 1Gbps network to ensure that the network doesn't impact the comparison.
 
-- GDLauncher: `0.52m`
-- Twitch Launcher: `2.25m`
+- GDLauncher: `52s`
+- Twitch Launcher: `145s`
 
 <p align="center">
     <img width="800" height="auto" src="https://gdevs.io/comparison.gif" alt="GDLauncher" />


### PR DESCRIPTION
## Purpose
The benchmark times were shown as M.S which is incorrect because there are 60 seconds in a minute, not 100.

## Approach
The times were changed to be only seconds. 2:25 becomes 145s

