### PR TITLE
fix: 🐛 game version of curseforge modpacks

### DIFF
--- a/src/common/modals/ModpackDescription.js
+++ b/src/common/modals/ModpackDescription.js
@@ -158,7 +158,7 @@ const ModpackDescription = ({
                     <label>MC version: </label>
                     {type === 'ftb'
                       ? modpack.tags[0]?.name || '-'
-                      : modpack.latestFilesIndexes[0].gameVersions}
+                      : modpack.latestFilesIndexes[0].gameVersions || modpack.latestFilesIndexes[0].gameVersion}
                   </div>
                 </ParallaxContentInfos>
                 <Button

--- a/src/common/modals/ModpackDescription.js
+++ b/src/common/modals/ModpackDescription.js
@@ -158,7 +158,7 @@ const ModpackDescription = ({
                     <label>MC version: </label>
                     {type === 'ftb'
                       ? modpack.tags[0]?.name || '-'
-                      : modpack.latestFilesIndexes[0].gameVersions || modpack.latestFilesIndexes[0].gameVersion}
+                      : modpack.latestFilesIndexes[0].gameVersion}
                   </div>
                 </ParallaxContentInfos>
                 <Button


### PR DESCRIPTION
## Purpose
_This fixes an error where the game version of curseforge modpacks wasn't displayed._
_If this fix was already introduced in another PR, feel free to close._

## Approach
_The change now uses `modpack?.latestFilesIndexes[0].gameVersion` if `...gameVersions` returns undefined, since the curseforge payload does not return multiple versions, or at least I didn't find any other properties._

_I am using the ||, other known as the OR operator. If gameVersions is null, undefined or has a falsy value (false or 0 for example)
it will switch to .gameVersion._

_Now you might ask yourself, what if that is also undefined?
That is an excellent question, go yell at Curseforge then. It will behave as before, not showing anything._

## Learning
_I simply debugged using good ol console.log() to check the object that was used to gain access to the gameVersion(s)._

## Update
_After reconsideration, gameVersions will never work, so I removed it._