### PR TITLE
Mac path changes

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -690,7 +690,7 @@ ipcMain.handle('installUpdateAndQuitOrRestart', async (e, quitAfterInstall) => {
 
     await fs.writeFile(
       path.join(tempFolder, updaterVbs),
-      `Set WshShell = CreateObject("WScript.Shell") 
+      `Set WshShell = CreateObject("WScript.Shell")
           WshShell.Run chr(34) & "${path.join(
             tempFolder,
             updaterBat
@@ -702,7 +702,6 @@ ipcMain.handle('installUpdateAndQuitOrRestart', async (e, quitAfterInstall) => {
     const updateSpawn = spawn(path.join(tempFolder, updaterVbs), {
       cwd: path.dirname(app.getPath('exe')),
       detached: true,
-      shell: true,
       stdio: [
         'ignore' /* stdin */,
         'ignore' /* stdout */,

--- a/src/app/desktop/utils/index.js
+++ b/src/app/desktop/utils/index.js
@@ -683,9 +683,9 @@ export const getJVMArguments113 = (
   }
 
   if (resolution) {
-    args.push("--width");
+    args.push('--width');
     args.push(resolution.width.toString());
-    args.push("--height");
+    args.push('--height');
     args.push(resolution.height.toString());
   }
 
@@ -768,6 +768,7 @@ export const patchForge113 = async (
       const mainClass = await readJarManifest(filePath, 'Main-Class');
 
       await new Promise(resolve => {
+        /* eslint-disable prettier/prettier */
         const ps = spawn(
           javaPath,
           [
@@ -777,6 +778,7 @@ export const patchForge113 = async (
             ...args
           ]
         );
+        /* eslint-enable prettier/prettier */
 
         ps.stdout.on('data', data => {
           console.log(data.toString());

--- a/src/app/desktop/utils/index.js
+++ b/src/app/desktop/utils/index.js
@@ -500,8 +500,8 @@ export const getJVMArguments112 = (
   args.push(`-Xmx${memory}m`);
   args.push(`-Xms${memory}m`);
   args.push(...jvmOptions);
-  args.push(`-Djava.library.path="${path.join(instancePath, 'natives')}"`);
-  args.push(`-Dminecraft.applet.TargetDirectory="${instancePath}"`);
+  args.push(`-Djava.library.path=${path.join(instancePath, 'natives')}`);
+  args.push(`-Dminecraft.applet.TargetDirectory=${instancePath}`);
   if (mcJson.logging) {
     args.push(mcJson?.logging?.client?.argument || '');
   }
@@ -593,7 +593,7 @@ export const getJVMArguments113 = (
 
   args.push(`-Xmx${memory}m`);
   args.push(`-Xms${memory}m`);
-  args.push(`-Dminecraft.applet.TargetDirectory="${instancePath}"`);
+  args.push(`-Dminecraft.applet.TargetDirectory=${instancePath}`);
   if (mcJson.logging) {
     args.push(mcJson?.logging?.client?.argument || '');
   }
@@ -611,9 +611,9 @@ export const getJVMArguments113 = (
   for (let i = 0; i < args.length; i += 1) {
     if (typeof args[i] === 'object' && args[i].rules) {
       if (typeof args[i].value === 'string') {
-        args[i] = `"${args[i].value}"`;
+        args[i] = args[i].value;
       } else if (typeof args[i].value === 'object') {
-        args.splice(i, 1, ...args[i].value.map(v => `"${v}"`));
+        args.splice(i, 1, ...args[i].value.map(v => v.toString()));
       }
       i -= 1;
     } else if (typeof args[i] === 'string') {
@@ -628,10 +628,10 @@ export const getJVMArguments113 = (
             val = mcJson.id;
             break;
           case 'game_directory':
-            val = `"${instancePath}"`;
+            val = instancePath;
             break;
           case 'assets_root':
-            val = `"${assetsPath}"`;
+            val = assetsPath;
             break;
           case 'assets_index_name':
             val = mcJson.assets;
@@ -657,7 +657,7 @@ export const getJVMArguments113 = (
           case 'natives_directory':
             val = args[i].replace(
               argDiscovery,
-              `"${path.join(instancePath, 'natives')}"`
+              path.join(instancePath, 'natives')
             );
             break;
           case 'launcher_name':
@@ -669,7 +669,7 @@ export const getJVMArguments113 = (
           case 'classpath':
             val = [...libraries, mcjar]
               .filter(l => !l.natives)
-              .map(l => `"${l.path}"`)
+              .map(l => l.path)
               .join(process.platform === 'win32' ? ';' : ':');
             break;
           default:
@@ -683,8 +683,10 @@ export const getJVMArguments113 = (
   }
 
   if (resolution) {
-    args.push(`--width ${resolution.width}`);
-    args.push(`--height ${resolution.height}`);
+    args.push("--width");
+    args.push(resolution.width.toString());
+    args.push("--height");
+    args.push(resolution.height.toString());
   }
 
   args = args.filter(arg => {
@@ -730,11 +732,11 @@ export const patchForge113 = async (
     // Fix forge madness
     return arg
       .replace('{SIDE}', `client`)
-      .replace('{ROOT}', `"${path.dirname(installerPath)}"`)
-      .replace('{MINECRAFT_JAR}', `"${mainJar}"`)
-      .replace('{MINECRAFT_VERSION}', `"${mcJsonPath}"`)
-      .replace('{INSTALLER}', `"${installerPath}"`)
-      .replace('{LIBRARY_DIR}', `"${librariesPath}"`);
+      .replace('{ROOT}', path.dirname(installerPath))
+      .replace('{MINECRAFT_JAR}', mainJar)
+      .replace('{MINECRAFT_VERSION}', mcJsonPath)
+      .replace('{INSTALLER}', installerPath)
+      .replace('{LIBRARY_DIR}', librariesPath);
   };
   const computePathIfPossible = arg => {
     if (arg[0] === '[') {
@@ -767,14 +769,13 @@ export const patchForge113 = async (
 
       await new Promise(resolve => {
         const ps = spawn(
-          `"${javaPath}"`,
+          javaPath,
           [
             '-classpath',
-            [`"${filePath}"`, ...classPaths].join(path.delimiter),
+            [filePath, ...classPaths].join(path.delimiter),
             mainClass,
             ...args
-          ],
-          { shell: true }
+          ]
         );
 
         ps.stdout.on('data', data => {

--- a/src/common/reducers/actions.js
+++ b/src/common/reducers/actions.js
@@ -2874,7 +2874,7 @@ export function launchInstance(instanceName, forceQuit = false) {
                   .replace(/\${version_name}/g, mcJson.id)
                   .replace(
                     /=\${library_directory}/g,
-                    `="${_getLibrariesPath(state)}"`
+                    `=${_getLibrariesPath(state)}`
                   )
                   .replace(
                     /\${library_directory}/g,
@@ -2998,12 +2998,12 @@ export function launchInstance(instanceName, forceQuit = false) {
         gameResolution,
         true,
         javaArguments
-      ).join(' ')}`
+      ).join('\n')}`
         .replace(...replaceRegex)
         .replace(
           // eslint-disable-next-line no-template-curly-in-string
           '-Dlog4j.configurationFile=${path}',
-          `-Dlog4j.configurationFile="${loggingPath}"`
+          `-Dlog4j.configurationFile=${loggingPath}`
         )
     );
 
@@ -3014,7 +3014,7 @@ export function launchInstance(instanceName, forceQuit = false) {
     let closed = false;
 
     const ps = spawn(
-      `"${javaPath}"`,
+      javaPath,
       jvmArguments.map(v =>
         v
           .toString()
@@ -3026,8 +3026,7 @@ export function launchInstance(instanceName, forceQuit = false) {
           )
       ),
       {
-        cwd: instancePath,
-        shell: true
+        cwd: instancePath
       }
     );
 


### PR DESCRIPTION
## Purpose
These address #1337 for me.  I am not sure if there are other changes necessary for Windows.

## Approach
This does not invoke the shell; instead it constructs the command line and passes it directly to `spawn`.  This means that the shell's automatic argument splitting with spaces, which is the root of the problem, doesn't apply.  It would also work around things like `$` or `*` or other shell metacharacters showing up in pathnames.

#### Open Questions and Pre-Merge TODOs
- [ ] Not sure if this works on Mac
- [ ] Need to test forge install
