### PR TITLE
Updated base URL for fetching news images

### DIFF
--- a/src/common/reducers/actions.js
+++ b/src/common/reducers/actions.js
@@ -256,7 +256,7 @@ export function initNews() {
           parser.parse(newsXml)?.rss?.channel?.item?.map(newsEntry => ({
             title: newsEntry.title,
             description: newsEntry.description,
-            image: `https://minecraft.net${newsEntry.imageURL}`,
+            image: `https://www.minecraft.net${newsEntry.imageURL}`,
             url: newsEntry.link,
             guid: newsEntry.guid
           })) || [];


### PR DESCRIPTION
## Purpose
When fetching news from Mojang, there is typically an image to each news item. The base URL of the image should be https://www.minecraft.net/, and not https://minecraft.net/.

## Approach
The change in this pull request ensures that https://www.minecraft.net/ is used as the base URL when fetching news images.