### PR TITLE
Absolute paths for Minecraft 1.12.2 and earlier.

### DIFF
--- a/src/common/reducers/actions.js
+++ b/src/common/reducers/actions.js
@@ -3185,7 +3185,7 @@ export function launchInstance(instanceName, forceQuit = false) {
     }
 
     const replaceRegex = [
-      process.platform === 'win32'
+      process.platform === 'win32' && gt(coerce(loader?.mcVersion), coerce('1.12.2'))
         ? new RegExp(userData.replace(/([.?*+^$[\]\\(){}|-])/g, '\\$1'), 'g')
         : null,
       replaceWith


### PR DESCRIPTION
## Purpose
Forge for Minecraft 1.12.2 and earlier do not fully support relative paths, causing some instances to fail.  Here are some easy steps to reproduce the problem:

1. Create a Forge 1.12.2 instance.
2. Add the mod "Equipment Compare" to the instance.
3. Launch the instance.

It can be seen from the latest.log file that Forge has tried to search the same directory twice, once with the relative path and once with a non-normalized absolute path.
Other launchers appear use absolute paths to specify game directory and such, which bypasses this issue.

## Approach
Add a check in launchInstance to bypass the relative path string replacement when the Minecraft version is 1.12.2 or lower.

