### PR TITLE
More graceful handling of blocked Curseforge browser downloads

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -582,6 +582,20 @@ ipcMain.handle('openFolder', (e, folderPath) => {
   shell.openPath(folderPath);
 });
 
+ipcMain.handle('openMainBrowserTo', (e, urls) => {
+  let start;
+  if (process.platform === 'darwin') {
+    start = 'open';
+  } else if (process.platform === 'win32') {
+    start = 'start';
+  } else {
+    start = 'xdg-open';
+  }
+  for (const url of urls) {
+    promisify(exec)(`${start} ${url}`);
+  }
+});
+
 ipcMain.handle('open-devtools', () => {
   mainWindow.webContents.openDevTools({ mode: 'undocked' });
 });

--- a/public/electron.js
+++ b/public/electron.js
@@ -784,15 +784,51 @@ ipcMain.handle('download-optedout-mods', async (e, { mods, instancePath }) => {
                 error: false,
                 warning: true
               });
-            } else if (details.statusCode === 403) {
-              // cloudflare
-              resolve();
-              mainWindow.webContents.send('opted-out-download-mod-status', {
-                modId: modManifest.id,
-                error: false,
-                warning: true,
-                cloudflareBlock: true
-              });
+            } else if (details.statusCode > 400) {
+              /**
+               * Check for Cloudflare blocking automated downloads.
+               *
+               * Sometimes, Cloudflare prevents the internal browser from navigating to the
+               * Curseforge mod download page and starting the download. The HTTP status code
+               * it returns is (generally) either 403 or 503. The code below retrieves the
+               * HTML of the page returned to the browser and checks for the title and some
+               * content on the page to determine if the returned page is Cloudflare.
+               * Unfortunately using the `webContents.getTitle()` returns an empty string.
+               */
+              details.webContents
+                .executeJavaScript(
+                  `
+                    function getHTML () {
+                      return new Promise((resolve, reject) => { resolve(document.documentElement.innerHTML); });
+                    }
+                    getHTML();
+                  `
+                )
+                .then(content => {
+                  const isCloudflare =
+                    content.includes('Just a moment...') &&
+                    content.includes(
+                      'needs to review the security of your connection before proceeding.'
+                    );
+
+                  if (isCloudflare) {
+                    resolve();
+                    mainWindow.webContents.send(
+                      'opted-out-download-mod-status',
+                      {
+                        modId: modManifest.id,
+                        error: false,
+                        warning: true,
+                        cloudflareBlock: true
+                      }
+                    );
+                  }
+
+                  return null;
+                })
+                .catch(() => {
+                  // no-op
+                });
             }
           }
         );
@@ -943,7 +979,7 @@ ipcMain.handle('installUpdateAndQuitOrRestart', async (e, quitAfterInstall) => {
 
     await fs.writeFile(
       path.join(tempFolder, updaterVbs),
-      `Set WshShell = CreateObject("WScript.Shell") 
+      `Set WshShell = CreateObject("WScript.Shell")
           WshShell.Run chr(34) & "${path.join(
             tempFolder,
             updaterBat

--- a/public/electron.js
+++ b/public/electron.js
@@ -943,7 +943,7 @@ ipcMain.handle('installUpdateAndQuitOrRestart', async (e, quitAfterInstall) => {
 
     await fs.writeFile(
       path.join(tempFolder, updaterVbs),
-      `Set WshShell = CreateObject("WScript.Shell")
+      `Set WshShell = CreateObject("WScript.Shell") 
           WshShell.Run chr(34) & "${path.join(
             tempFolder,
             updaterBat

--- a/public/electron.js
+++ b/public/electron.js
@@ -784,6 +784,16 @@ ipcMain.handle('download-optedout-mods', async (e, { mods, instancePath }) => {
                 error: false,
                 warning: true
               });
+            } else if (details.statusCode === 403) {
+              // cloudflare
+              resolve();
+              mainWindow.webContents.send('opted-out-download-mod-status', {
+                modId: modManifest.id,
+                error: false,
+                warning: true,
+                cloudflareBlock: true,
+                urlDownloadPage
+              });
             }
           }
         );
@@ -934,7 +944,7 @@ ipcMain.handle('installUpdateAndQuitOrRestart', async (e, quitAfterInstall) => {
 
     await fs.writeFile(
       path.join(tempFolder, updaterVbs),
-      `Set WshShell = CreateObject("WScript.Shell") 
+      `Set WshShell = CreateObject("WScript.Shell")
           WshShell.Run chr(34) & "${path.join(
             tempFolder,
             updaterBat

--- a/public/electron.js
+++ b/public/electron.js
@@ -592,7 +592,7 @@ ipcMain.handle('openMainBrowserTo', (e, urls) => {
     start = 'xdg-open';
   }
   for (const url of urls) {
-    promisify(exec)(`${start} ${url}`);
+    exec(`${start} ${url}`);
   }
 });
 

--- a/public/electron.js
+++ b/public/electron.js
@@ -582,20 +582,6 @@ ipcMain.handle('openFolder', (e, folderPath) => {
   shell.openPath(folderPath);
 });
 
-ipcMain.handle('openMainBrowserTo', (e, urls) => {
-  let start;
-  if (process.platform === 'darwin') {
-    start = 'open';
-  } else if (process.platform === 'win32') {
-    start = 'start';
-  } else {
-    start = 'xdg-open';
-  }
-  for (const url of urls) {
-    exec(`${start} ${url}`);
-  }
-});
-
 ipcMain.handle('open-devtools', () => {
   mainWindow.webContents.openDevTools({ mode: 'undocked' });
 });
@@ -805,8 +791,7 @@ ipcMain.handle('download-optedout-mods', async (e, { mods, instancePath }) => {
                 modId: modManifest.id,
                 error: false,
                 warning: true,
-                cloudflareBlock: true,
-                urlDownloadPage
+                cloudflareBlock: true
               });
             }
           }

--- a/src/common/modals/OptedOutModsList.js
+++ b/src/common/modals/OptedOutModsList.js
@@ -306,10 +306,7 @@ const OptedOutModsList = ({
                 type="primary"
                 disabled={downloading}
                 onClick={() => {
-                  console.log(
-                    '>>> MATT :: OptedOutModsList :: button 1 :: click'
-                  );
-                  // TODO
+                  ipcRenderer.invoke('openMainBrowserTo', manualDownloadUrls);
                 }}
                 css={`
                   background-color: ${props => props.theme.palette.colors.blue};
@@ -321,16 +318,13 @@ const OptedOutModsList = ({
                 type="primary"
                 disabled={downloading}
                 onClick={() => {
-                  console.log(
-                    '>>> MATT :: OptedOutModsList :: button 2 :: click'
-                  );
                   ipcRenderer.invoke('openFolder', instancePath);
                 }}
                 css={`
                   background-color: ${props => props.theme.palette.colors.blue};
                 `}
               >
-                Open mods folder
+                Open folder
               </Button>
               <Button
                 type="primary"

--- a/src/common/modals/OptedOutModsList.js
+++ b/src/common/modals/OptedOutModsList.js
@@ -3,7 +3,10 @@ import { LoadingOutlined } from '@ant-design/icons';
 import { useDispatch, useSelector } from 'react-redux';
 import { Button, Spin } from 'antd';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import {
+  faExclamationTriangle,
+  faFileDownload
+} from '@fortawesome/free-solid-svg-icons';
 import { ipcRenderer } from 'electron';
 import styled from 'styled-components';
 import Modal from '../components/Modal';
@@ -61,7 +64,8 @@ const ModRow = ({
   loadedMods,
   currentMod,
   missingMods,
-  cloudflareBlock
+  cloudflareBlock,
+  downloadUrl
 }) => {
   const { modManifest, addon } = mod;
   const loaded = loadedMods.includes(modManifest.id);
@@ -84,13 +88,18 @@ const ModRow = ({
     <RowContainer ref={ref}>
       <div>{`${addon?.name} - ${modManifest?.displayName}`}</div>
       {loaded && !missing && !cloudflareBlock && <div className="dot" />}
-      {loaded && (missing || cloudflareBlock) && (
+      {loaded && missing && !cloudflareBlock && (
         <FontAwesomeIcon
           icon={faExclamationTriangle}
           css={`
             color: ${props => props.theme.palette.colors.yellow};
           `}
         />
+      )}
+      {loaded && !missing && cloudflareBlock && (
+        <Button href={downloadUrl}>
+          <FontAwesomeIcon icon={faFileDownload} />
+        </Button>
       )}
       {!loaded && isCurrentMod && (
         <Spin indicator={<LoadingOutlined style={{ fontSize: 24 }} spin />} />
@@ -155,7 +164,7 @@ const OptedOutModsList = ({
             setMissingMods(prev => [...prev, status.modId]);
           } else {
             setCloudflareBlock(true);
-            setManualDownloadUrls(prev => [...prev, status.urlDownloadPage]);
+            setManualDownloadUrls(prev => [...prev, status.modId]);
           }
         }
       } else {
@@ -206,26 +215,30 @@ const OptedOutModsList = ({
         </div>
         <ModsContainer>
           {optedOutMods &&
-            optedOutMods.map(mod => (
-              <ModRow
-                mod={mod}
-                loadedMods={loadedMods}
-                currentMod={currentMod}
-                missingMods={missingMods}
-                cloudflareBlock={cloudflareBlock}
-              />
-            ))}
+            optedOutMods.map(mod => {
+              return (
+                <ModRow
+                  mod={mod}
+                  loadedMods={loadedMods}
+                  currentMod={currentMod}
+                  missingMods={missingMods}
+                  cloudflareBlock={cloudflareBlock}
+                  downloadUrl={`${mod.addon.links.websiteUrl}/download/${mod.modManifest.id}`}
+                />
+              );
+            })}
         </ModsContainer>
         {cloudflareBlock && (
           <p
             css={`
-              width: 80%;
+              width: 90%;
               margin: 20px auto 0 auto;
             `}
           >
             Cloudflare is currently blocking automated downloads. You can
-            manually download the mods and place them in the mods folder if you
-            want.
+            manually download the mods and place them in the mods folder to
+            continue. Use the download buttons in the rows above, and the button
+            below to open the instance folder.
           </p>
         )}
         <div
@@ -302,18 +315,6 @@ const OptedOutModsList = ({
           )}
           {cloudflareBlock && (
             <>
-              <Button
-                type="primary"
-                disabled={downloading}
-                onClick={() => {
-                  ipcRenderer.invoke('openMainBrowserTo', manualDownloadUrls);
-                }}
-                css={`
-                  background-color: ${props => props.theme.palette.colors.blue};
-                `}
-              >
-                Open Browser
-              </Button>
               <Button
                 type="primary"
                 disabled={downloading}


### PR DESCRIPTION
## Purpose

This PR attempts to more gracefully handle Curseforge blocking automated downloads of mods.

Related: many posts in Discord.

Fixes #1367, #1520.

## Approach

If the Electron browser detects an HTTP 403 response from Curseforge, it notifies the webapp of such. Following the (attempted) downloading of all mods, the user is presented with info text and the ability to open the instance's folder. The list of missing mods includes links to download those mods themselves. This bypasses / gets around the automated download protection by (1) using the user's main browser which is more likely to be easily fingerprintable, and (2) allowing the user time to confirm captchas or other human-verification mechanics.

![1](https://user-images.githubusercontent.com/772507/212796582-94e5a253-f1ec-4f28-a099-f3d2f9a060d2.PNG)
![2](https://user-images.githubusercontent.com/772507/212760220-af8f76be-5ff3-47a7-bf6f-5a91d913f60d.PNG)
![3](https://user-images.githubusercontent.com/772507/212760223-f2328422-0feb-4325-a9cb-5f0aaf12b3dc.PNG)

## Learning

The issues I faced were mostly to the system I was running on. WSL + VcXsrv is tedious at best, installing Node/Rust/Choco/Python/openssl etc. on Windows didn't go well, so I had to reach for VirtualBox, set up a new graphical install there, and test the code.

The only other thing I'd mention is that there doesn't seem to be hot-module replacement. This may have not been implemented, for any number of reasons, but did slow down development.