### PR TITLE
Update microsoft URI from HTTP to HTTPS - #1513

### DIFF
--- a/src/common/utils/constants.js
+++ b/src/common/utils/constants.js
@@ -1,6 +1,6 @@
 export const MC_MANIFEST_URL =
   'https://launchermeta.mojang.com/mc/game/version_manifest.json';
-export const MC_RESOURCES_URL = 'http://resources.download.minecraft.net';
+export const MC_RESOURCES_URL = 'https://resources.download.minecraft.net';
 export const FABRIC_APIS = 'https://meta.fabricmc.net/v2';
 export const GDL_LEGACYJAVAFIXER_MOD_URL =
   'https://gdevs.io/legacyjavafixer-1.0.jar';


### PR DESCRIPTION
Microsoft URI requires HTTPS.

## Purpose
Requesting urls from microsoft throws 400 when http.   Https solves this. 
## Approach
force the url to use HTTPS
#### Open Questions and Pre-Merge TODOs
none



