### PR TITLE
Fix java arch

### DIFF
--- a/src/app/desktop/utils/index.js
+++ b/src/app/desktop/utils/index.js
@@ -84,7 +84,7 @@ export const convertOSToJavaFormat = ElectronFormat => {
 export const convertArchToJavaFormat = ElectronFormat => {
   switch (ElectronFormat) {
     case 'x64':
-      return 'amd64';
+      return 'x64';
     case 'ia32':
       return 'x32';
     case 'arm':


### PR DESCRIPTION
The recent #1451 had the java arch other than what we have in the java manifest file, fixed that.

The wrong arch results in not finding the corresponding java version and a fatal error of the app on startup.