### PR TITLE
Add delete confirmation and and restore option to canceled downloads

### DIFF
--- a/scripts/createDeploy.js
+++ b/scripts/createDeploy.js
@@ -77,6 +77,7 @@ const createDeployFiles = async () => {
           if (err) {
             reject();
           }
+          destination.close();
           resolve();
         });
       });

--- a/src/app/desktop/utils/downloader.js
+++ b/src/app/desktop/utils/downloader.js
@@ -103,8 +103,10 @@ const downloadFileInstance = async (fileName, url, sha1, legacyPath) => {
 
       data.on('end', () => {
         wStream.end();
+        wStream.close();
         if (legacyPath) {
           wStreamLegacy.end();
+          wStreamLegacy.close();
         }
         resolve();
       });
@@ -148,6 +150,7 @@ export const downloadFile = async (fileName, url, onProgress) => {
   return new Promise((resolve, reject) => {
     data.on('end', () => {
       out.end();
+      out.close();
       resolve();
     });
 

--- a/src/common/modals/InstanceDeleteConfirmation.js
+++ b/src/common/modals/InstanceDeleteConfirmation.js
@@ -67,7 +67,12 @@ const InstanceDeleteConfirmation = ({ instanceName }) => {
           >
             No, Abort
           </Button>
-          <Button onClick={deleteInstance} loading={loading}>
+          <Button
+            danger
+            type="primary"
+            onClick={deleteInstance}
+            loading={loading}
+          >
             Yes, Delete
           </Button>
         </div>

--- a/src/common/modals/InstanceDownloadFailed.js
+++ b/src/common/modals/InstanceDownloadFailed.js
@@ -8,7 +8,7 @@ import {
   removeDownloadFromQueue,
   updateInstanceConfig
 } from '../reducers/actions';
-import { closeModal } from '../reducers/modals/actions';
+import { openModal, closeModal } from '../reducers/modals/actions';
 import { _getInstancesPath, _getTempPath } from '../utils/selectors';
 import { rollBackInstanceZip } from '../utils';
 
@@ -28,7 +28,15 @@ const InstanceDownloadFailed = ({
       ? `${instanceName.substring(0, 20)}...`
       : instanceName;
 
-  const cancelDownload = async () => {
+  const deleteDownload = async () => {
+    await dispatch(removeDownloadFromQueue(instanceName, true));
+
+    dispatch(closeModal());
+    await new Promise(resolve => setTimeout(resolve, 1000));
+    dispatch(openModal('InstanceDeleteConfirmation', { instanceName }));
+  };
+
+  const restoreDownload = async () => {
     await dispatch(removeDownloadFromQueue(instanceName, true));
     setLoading(true);
     await new Promise(resolve => setTimeout(resolve, 1000));
@@ -87,11 +95,21 @@ const InstanceDownloadFailed = ({
           <Button
             variant="contained"
             color="primary"
-            onClick={cancelDownload}
-            loading={loading}
+            onClick={deleteDownload}
+            disabled={loading}
           >
-            Cancel Download
+            Delete Instance
           </Button>
+          {isUpdate && (
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={restoreDownload}
+              loading={loading}
+            >
+              Restore instance
+            </Button>
+          )}
           <Button danger type="primary" onClick={retry} disabled={loading}>
             Retry Download
           </Button>

--- a/src/common/modals/OptedOutModsList.js
+++ b/src/common/modals/OptedOutModsList.js
@@ -202,17 +202,19 @@ const OptedOutModsList = ({
       title="Opted out mods list"
     >
       <Container>
-        <div
-          css={`
-            text-align: left;
-            margin-bottom: 2rem;
-          `}
-        >
-          Hey oh! It looks like some developers opted out from showing their
-          mods on third-party launchers. We can still attempt to download them
-          automatically. Please click continue and wait for all downloads to
-          finish. Please don&apos;t click anything inside the browser.
-        </div>
+        {!cloudflareBlock && (
+          <div
+            css={`
+              text-align: left;
+              margin-bottom: 2rem;
+            `}
+          >
+            Hey oh! It looks like some developers opted out from showing their
+            mods on third-party launchers. We can still attempt to download them
+            automatically. Please click continue and wait for all downloads to
+            finish. Please don&apos;t click anything inside the browser.
+          </div>
+        )}
         <ModsContainer>
           {optedOutMods &&
             optedOutMods.map(mod => {
@@ -231,7 +233,6 @@ const OptedOutModsList = ({
         {cloudflareBlock && (
           <p
             css={`
-              width: 90%;
               margin: 20px auto 0 auto;
             `}
           >
@@ -254,7 +255,9 @@ const OptedOutModsList = ({
           <Button
             danger
             type="text"
-            disabled={downloading || loadedMods.length !== 0}
+            disabled={
+              (missingMods.length > 0 && !cloudflareBlock) || downloading
+            }
             onClick={() => {
               dispatch(closeModal());
               setTimeout(
@@ -290,6 +293,7 @@ const OptedOutModsList = ({
                   mods: optedOutMods,
                   instancePath
                 });
+                setDownloading(false);
               }}
               css={`
                 background-color: ${props => props.theme.palette.colors.green};

--- a/src/common/reducers/actions.js
+++ b/src/common/reducers/actions.js
@@ -1068,6 +1068,7 @@ export function updateInstanceConfig(
         if (readBuff.every(v => v === 0)) {
           throw new Error('Corrupted file');
         }
+        newFile.close();
         await fs.rename(tempP, p);
       };
 
@@ -2704,12 +2705,15 @@ export const startListener = () => {
             !changesTracker[completePath].completed &&
             (event.action === 2 || event.action === 0 || event.action === 1)
           ) {
+            let filehandle;
             try {
               await new Promise(resolve => setTimeout(resolve, 300));
-              await fs.open(completePath, 'r+');
+              filehandle = await fs.open(completePath, 'r+');
               changesTracker[completePath].completed = true;
             } catch {
               // Do nothing, simply not completed..
+            } finally {
+              await filehandle?.close();
             }
           }
         })
@@ -3762,6 +3766,7 @@ export const checkForPortableUpdates = () => {
                   if (err) {
                     reject(err);
                   }
+                  destination.close();
                   resolve();
                 });
               });

--- a/src/common/reducers/actions.js
+++ b/src/common/reducers/actions.js
@@ -2233,6 +2233,7 @@ export function downloadInstance(instanceName) {
 
       await dispatch(removeDownloadFromQueue(instanceName));
       dispatch(addNextInstanceToCurrentDownload());
+      await remove(tempInstancePath);
     } catch (err) {
       console.error(err);
       // Show error modal and decide what to do
@@ -2244,8 +2245,6 @@ export function downloadInstance(instanceName) {
           isUpdate
         })
       );
-    } finally {
-      await remove(tempInstancePath);
     }
   };
 }

--- a/src/common/utils/index.js
+++ b/src/common/utils/index.js
@@ -232,7 +232,7 @@ export const makeInstanceRestorePoint = async (
     await access(newInstancePath);
     await remove(newInstancePath);
   } catch (e) {
-    console.warn(e);
+    console.log('Expected ENOENT:', e);
   }
   await makeDir(newInstancePath);
   try {


### PR DESCRIPTION
This pr adds delete confirmation and a restore option to to failed downloads.
It also fixes some deprecated warnings in the console about unclosed file handles.

Fixes #1288 